### PR TITLE
Fix bss version scanning in clang based builds

### DIFF
--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -91,7 +91,7 @@ pub fn parse_binary(_pid: remoteprocess::Pid, filename: &Path, addr: u64, size: 
         Object::Elf(elf) => {
             let bss_header = elf.section_headers
                 .iter()
-                .find(|ref header| header.sh_type == goblin::elf::section_header::SHT_NOBITS)
+                .find(|ref header| header.sh_type == goblin::elf::section_header::SHT_NOBITS && elf.shdr_strtab.get_at(header.sh_name).unwrap_or("") == ".bss")
                 .ok_or_else(|| format_err!("Failed to find BSS section header in {}", filename.display()))?;
 
             let program_header = elf.program_headers

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -556,7 +556,7 @@ fn get_python_version(python_info: &PythonProcessInfo, process: &remoteprocess::
 
     // otherwise get version info from scanning BSS section for sys.version string
     if let Some(ref pb) = python_info.python_binary {
-        info!("Getting version from python binary BSS");
+        info!("Getting version from python binary BSS. addr: 0x{:x}, size: 0x{:x}", pb.bss_addr, pb.bss_size);
         let bss = process.copy(pb.bss_addr as usize,
                                pb.bss_size as usize)?;
         match Version::scan_bytes(&bss) {


### PR DESCRIPTION
Relevant for python linked using clang and more specifically in executables with embedded python interpreter such as [PyOxidizer](https://github.com/indygreg/PyOxidizer)